### PR TITLE
Fix an issue causing the app crash

### DIFF
--- a/Example/Views/AccordionViewController.swift
+++ b/Example/Views/AccordionViewController.swift
@@ -43,12 +43,7 @@ extension AccordionViewController {
     /// Configure the data source 
     private func configDataSource() {
         
-        let groupA = Parent(state: .expanded, item: GroupCellModel(name: "Group A"),
-                            childs: [CountryCellModel(name: "Uruguay"),
-                                     CountryCellModel(name: "Russia"),
-                                     CountryCellModel(name: "Saudi Arabia"),
-                                     CountryCellModel(name: "Egypt")]
-        )
+        let groupA = Parent(state: .expanded, item: GroupCellModel(name: "Group A"), childs: [CountryCellModel]())
         
         let groupB = Parent(state: .expanded, item: GroupCellModel(name: "Group B"),
                             childs: [CountryCellModel(name: "Spain"),

--- a/Source/DataSourceProvider.swift
+++ b/Source/DataSourceProvider.swift
@@ -126,10 +126,14 @@ extension DataSourceProvider {
     private func update(_ tableView: UITableView, _ item: DataSource.Item?, _ currentPosition: Int, _ indexPath: IndexPath, _ parentIndex: Int) {
         tableView.beginUpdates()
         
+        let numberOfChilds = item!.childs.count
+        
+        // If the cell doesn't have any child then return
+        guard numberOfChilds > 0 else { return }
+        
         switch (item!.state) {
         case .expanded:
             
-            let numberOfChilds = item!.childs.count
             let indexPaths = (currentPosition + 1...currentPosition + numberOfChilds)
                 .map { IndexPath(row: $0, section: indexPath.section)}
             
@@ -138,7 +142,6 @@ extension DataSourceProvider {
             
         case .collapsed:
             
-            let numberOfChilds = item!.childs.count
             var insertPos = indexPath.row + 1
             
             let indexPaths = (0..<numberOfChilds)


### PR DESCRIPTION
This PR can be resume in the following:

• Fix an issue causing the app crash when a Parent cell does not contain any Child cell.
• Remove the Child cells from the Group A in the `AccordionViewController` example.

To be able to support an empty child cell is necessary to explicitly specify to the compiler the type of the empty array, otherwise, the compiler would infer the type of the array as `Any`, for example:

```swift
let groupA = Parent(state: .expanded, item: GroupCellModel(name: "Group A"), childs: [])
```

The type of the `groupA` should be:

```swift
let groupA: Parent<GroupCellModel, Any>
```

Causing the following error during the creation of the `Section`:
```swift
Cannot convert value of type '[Any]' to expected argument type '[_]'
```

To be able to solve it's necessary to specify explicitly the type of the array to be used like this:

```swift
let groupA = Parent(state: .expanded, item: GroupCellModel(name: "Group A"), childs: [CountryCellModel]())
```

or

```swift
let groupA:  Parent<GroupCellModel, CountryCellModel> = Parent(state: .expanded, item: GroupCellModel(name: "Group A"), childs: [])
```