### PR TITLE
Fix an issue causing the cells were not expanded

### DIFF
--- a/Source/DataSourceProvider.swift
+++ b/Source/DataSourceProvider.swift
@@ -124,12 +124,13 @@ extension DataSourceProvider {
     }
     
     private func update(_ tableView: UITableView, _ item: DataSource.Item?, _ currentPosition: Int, _ indexPath: IndexPath, _ parentIndex: Int) {
-        tableView.beginUpdates()
         
         let numberOfChilds = item!.childs.count
         
         // If the cell doesn't have any child then return
         guard numberOfChilds > 0 else { return }
+        
+        tableView.beginUpdates()
         
         switch (item!.state) {
         case .expanded:


### PR DESCRIPTION
This PR solve #42 and can be resumed in the following:

* Fix an issue causing after a Parent cell was tapped the rest of the Parent cells were not expanded regarding the `endUpdates()` on the `UITableView` was not called before a return. 