### PR TITLE
Decrease the minimum deployment target to iOS 10

### DIFF
--- a/AccordionSwift.podspec
+++ b/AccordionSwift.podspec
@@ -28,6 +28,6 @@ The best way of implement an accordion menu using an UITableView in Swift
   s.social_media_url = 'https://twitter.com/Vkt0r'
   s.swift_version    = '5.0'
 
-  s.ios.deployment_target = '11.4'
+  s.ios.deployment_target = '10.0'
   s.source_files = 'Source/*.swift'
 end

--- a/AccordionSwift.xcodeproj/project.pbxproj
+++ b/AccordionSwift.xcodeproj/project.pbxproj
@@ -602,7 +602,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -631,7 +631,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _An accordion/dropdown menu to integrate in your projects. This library is proto
 
 ## Requirements 💥
 - iOS 10.0+
-- Xcode 10.1+
+- Xcode 10.2+
 
 ## Installation
 
@@ -50,7 +50,7 @@ To integrate AccordionSwift into your Xcode project using CocoaPods, specify it 
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '10.0'
 use_frameworks!
 
 target '<Your Target Name>' do
@@ -65,7 +65,7 @@ $ pod install
 ```
 
 ## Usage ✨
-After import the framework the library can be used in a `UITableViewController` or a `UIViewController` and offers a full customization of the cells and data source:
+After importing the framework, the library can be used in a `UITableViewController` or a `UIViewController` and offers full customization of the cells and data source:
 
 ```swift
 import UIKit
@@ -147,4 +147,4 @@ Great! Please launch a [pull request](https://github.com/Vkt0r/AccordionMenu/pul
 
 License:
 =================
-The MIT License. See the LICENSE file for more infomation.
+The MIT License. See the [LICENSE file](LICENSE) for more information.


### PR DESCRIPTION
The update to Swift 5 did not require an increase in minimum deployment target and prevents some projects that use this as a dependency from getting the latest version. Please consider decreasing it to iOS 10.

Thank you for the great framework!