### PR TITLE
Make DataProvider extensible

### DIFF
--- a/Source/DataSource.swift
+++ b/Source/DataSource.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Defines a sectioned data source to be displayed in the UITableView
-public struct DataSource<Item: ParentType> {
+open class DataSource<Item: ParentType> {
     
     // MARK: - Properties
     
@@ -39,7 +39,7 @@ public struct DataSource<Item: ParentType> {
     /// - Parameters:
     ///   - item: The item to be inserted.
     ///   - indexPath: The index path specifying the location for the item.
-    public mutating func insert(item: Item, at indexPath: IndexPath) {
+    public func insert(item: Item, at indexPath: IndexPath) {
         insert(item: item, atRow: indexPath.row, inSection: indexPath.section)
     }
     
@@ -49,7 +49,7 @@ public struct DataSource<Item: ParentType> {
     ///   - item: The item to insert.
     ///   - row:  The row index of the item.
     ///   - section: The section index of the item.
-    public mutating func insert(item: Item, atRow row: Int, inSection section: Int) {
+    public func insert(item: Item, atRow row: Int, inSection section: Int) {
         guard section < numberOfSections() else { return }
         guard row <= numberOfItems(inSection: section) else { return }
         sections[section].items.insert(item, at: row)
@@ -60,7 +60,7 @@ public struct DataSource<Item: ParentType> {
     /// - Parameters:
     ///   - item:  The item to be added.
     ///   - section: The section location for the item.
-    public mutating func append(_ item: Item, inSection section: Int) {
+    public func append(_ item: Item, inSection section: Int) {
         guard let items = items(inSection: section) else { return }
         insert(item: item, atRow: items.endIndex, inSection: section)
     }
@@ -72,7 +72,7 @@ public struct DataSource<Item: ParentType> {
     ///   - section: The section location of the item.
     /// - Returns: The item removed, otherwise nil if it does not exist.
     @discardableResult
-    public mutating func remove(atRow row: Int, inSection section: Int) -> Item? {
+    public func remove(atRow row: Int, inSection section: Int) -> Item? {
         guard item(atRow: row, inSection: section) != nil else { return nil }
         return sections[section].items.remove(at: row)
     }
@@ -82,7 +82,7 @@ public struct DataSource<Item: ParentType> {
     /// - Parameter indexPath: The index path specifying the location of the item.
     /// - Returns:  The item at `indexPath`, otherwise nil if it does not exist.
     @discardableResult
-    public mutating func remove(at indexPath: IndexPath) -> Item? {
+    public func remove(at indexPath: IndexPath) -> Item? {
         return remove(atRow: indexPath.row, inSection: indexPath.section)
     }
     
@@ -144,14 +144,14 @@ extension DataSource: DataSourceType {
         return items[parentIndex].childs[row - currentPos - 1]
     }
     
-    public mutating func expandParent(atIndexPath indexPath: IndexPath, parentIndex: Int) {
+    public func expandParent(atIndexPath indexPath: IndexPath, parentIndex: Int) {
         let section = indexPath.section
         guard var items = items(inSection: section) else { return }
         items[parentIndex].state = .expanded
         sections[section].total += items[parentIndex].childs.count
     }
     
-    public mutating func collapseChilds(atIndexPath indexPath: IndexPath, parentIndex: Int) {
+    public func collapseChilds(atIndexPath indexPath: IndexPath, parentIndex: Int) {
         let section = indexPath.section
         guard var items = items(inSection: section) else { return }
         items[parentIndex].state = .collapsed

--- a/Source/DataSource.swift
+++ b/Source/DataSource.swift
@@ -9,62 +9,62 @@
 import Foundation
 
 /// Defines a sectioned data source to be displayed in the UITableView
-open class DataSource<Item: ParentType> {
-    
+open class DataSource<Item: ParentType>: DataSourceType {
+
     // MARK: - Properties
-    
+
     /// The sections in the data source.
-    public var sections: [Section<Item>]
-    
+    open var sections: [Section<Item>]
+
     // MARK: -  Initialization
-    
+
     /// Constructs a new DataSource.
     ///
     /// - Parameter sections: The sections for the data source.
     public init(_ sections: [Section<Item>]) {
         self.sections = sections
     }
-    
+
     /// Constructs a new DataSource.
     ///
     /// - Parameter sections: The sections for the data source.
     public init(sections: Section<Item>...) {
         self.sections = sections
     }
-    
+
     // MARK: - Methods
-    
+
     /// Inserts the item at the specified index path
     ///
     /// - Parameters:
     ///   - item: The item to be inserted.
     ///   - indexPath: The index path specifying the location for the item.
-    public func insert(item: Item, at indexPath: IndexPath) {
+    open func insert(item: Item, at indexPath: IndexPath) {
         insert(item: item, atRow: indexPath.row, inSection: indexPath.section)
     }
-    
+
     /// Inserts the item at the specified row and section.
     ///
     /// - Parameters:
     ///   - item: The item to insert.
     ///   - row:  The row index of the item.
     ///   - section: The section index of the item.
-    public func insert(item: Item, atRow row: Int, inSection section: Int) {
+    open func insert(item: Item, atRow row: Int, inSection section: Int) {
         guard section < numberOfSections() else { return }
         guard row <= numberOfItems(inSection: section) else { return }
         sections[section].items.insert(item, at: row)
     }
-    
+
     /// Add the item at the specified section.
     ///
     /// - Parameters:
     ///   - item:  The item to be added.
     ///   - section: The section location for the item.
-    public func append(_ item: Item, inSection section: Int) {
+    open func append(_ item: Item, inSection section: Int) {
         guard let items = items(inSection: section) else { return }
         insert(item: item, atRow: items.endIndex, inSection: section)
     }
-    
+
     /// Removes the item at the specified row and section.
     ///
     /// - Parameters:
@@ -72,90 +72,86 @@ open class DataSource<Item: ParentType> {
     ///   - section: The section location of the item.
     /// - Returns: The item removed, otherwise nil if it does not exist.
     @discardableResult
-    public func remove(atRow row: Int, inSection section: Int) -> Item? {
+    open func remove(atRow row: Int, inSection section: Int) -> Item? {
         guard item(atRow: row, inSection: section) != nil else { return nil }
         return sections[section].items.remove(at: row)
     }
-    
+
     /// Removes the item at the specified index path.
     ///
     /// - Parameter indexPath: The index path specifying the location of the item.
     /// - Returns:  The item at `indexPath`, otherwise nil if it does not exist.
     @discardableResult
-    public func remove(at indexPath: IndexPath) -> Item? {
+    open func remove(at indexPath: IndexPath) -> Item? {
         return remove(atRow: indexPath.row, inSection: indexPath.section)
     }
-    
+
     // MARK: - Subscripts
-    
+
     /// The section at the specified index.
     ///
     /// - Parameter index: The index of a section.
-    public subscript (index: Int) -> Section<Item> {
+    open subscript (index: Int) -> Section<Item> {
         get { return sections[index] }
         set { sections[index] = newValue }
     }
-    
+
     /// The item at the specified index path.
     ///
     /// - Parameter indexPath: The index path of an item.
-    public subscript (indexPath: IndexPath) -> Item {
+    open subscript (indexPath: IndexPath) -> Item {
         get { return sections[indexPath.section].items[indexPath.row] }
         set { sections[indexPath.section].items[indexPath.row] = newValue }
     }
-}
 
-extension DataSource: DataSourceType {
-    
     // MARK: - DataSourceType Methods
-    
-    public func numberOfSections() -> Int {
+
+    open func numberOfSections() -> Int {
         return sections.count
     }
-    
-    public func numberOfItems(inSection section: Int) -> Int {
+
+    open func numberOfItems(inSection section: Int) -> Int {
         guard section < sections.count else { return 0 }
         return sections[section].total
     }
-    
-    public func items(inSection section: Int) -> [Item]? {
+
+    open func items(inSection section: Int) -> [Item]? {
         guard section < sections.count else { return nil }
         return sections[section].items
     }
-    
-    public func item(atRow row: Int, inSection section: Int) -> Item? {
+
+    open func item(atRow row: Int, inSection section: Int) -> Item? {
         guard let items = items(inSection: section) else { return nil }
         guard row < items.count else { return nil }
         return items[row]
     }
-    
-    public func headerTitle(inSection section: Int) -> String? {
+
+    open func headerTitle(inSection section: Int) -> String? {
         guard section < sections.count else { return nil }
         return sections[section].headerTitle
     }
-    
-    public func footerTitle(inSection section: Int) -> String? {
+
+    open func footerTitle(inSection section: Int) -> String? {
         guard section < sections.count else { return nil }
         return sections[section].footerTitle
     }
-    
-    public func childItem(atRow row: Int, inSection section: Int, parentIndex: Int, currentPos: Int) -> Item.ChildItem? {
+
+    open func childItem(atRow row: Int, inSection section: Int, parentIndex: Int, currentPos: Int) -> Item.ChildItem? {
         guard let items = items(inSection: section) else { return nil }
         return items[parentIndex].childs[row - currentPos - 1]
     }
-    
-    public func expandParent(atIndexPath indexPath: IndexPath, parentIndex: Int) {
+
+    open func expandParent(atIndexPath indexPath: IndexPath, parentIndex: Int) {
         let section = indexPath.section
         guard var items = items(inSection: section) else { return }
         items[parentIndex].state = .expanded
         sections[section].total += items[parentIndex].childs.count
     }
-    
-    public func collapseChilds(atIndexPath indexPath: IndexPath, parentIndex: Int) {
+
+    open func collapseChilds(atIndexPath indexPath: IndexPath, parentIndex: Int) {
         let section = indexPath.section
         guard var items = items(inSection: section) else { return }
         items[parentIndex].state = .collapsed
         sections[section].total -= items[parentIndex].childs.count
     }
 }
-


### PR DESCRIPTION
Use case: As an application developer, I would like to override the `expandParent` and `collapseChilds` methods of the `DataSource` struct so that I can extend the behaviour of the framework

There are a few obstacles to this:
- `DataProvider` is a struct, and therefore cannot be subclassed
- `DataProvider` is `public`, and therefore cannot be subclassed outside of it's module, such as an application pulling this framework in as a dependency
- The implementation of the methods mentioned above are in an extension of `DataSource` which implements the `DataSourceType`. Methods declared in extensions cannot be overriden

What are your thoughts on this? I will make a ticket detailing the behaviour I would like to achieve and hopefully be able to submit a PR with it after getting your thoughts.

Thank you!