### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "AccordionSwift",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(
+            name: "AccordionSwift",
+            targets: ["AccordionSwift"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "AccordionSwift",
+            path: "Source"
+        )
+    ]
+)

--- a/Source/CellViewConfig.swift
+++ b/Source/CellViewConfig.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Victor Sigler. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// Defines a cell config type to handle a UITableViewCell
 public protocol CellViewConfigType {

--- a/Source/DataSourceProvider.swift
+++ b/Source/DataSourceProvider.swift
@@ -7,7 +7,7 @@
 //  Copyright © 2018 Victor Sigler. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 // Defines if there can be multiple cells expanded at once
 public enum NumberOfExpandedParentCells {

--- a/Source/TableViewDataSource.swift
+++ b/Source/TableViewDataSource.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Victor Sigler. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 typealias NumberOfSectionsClosure = () -> Int
 typealias NumberOfItemsInSectionClosure = (Int) -> Int

--- a/Source/TableViewDelegate.swift
+++ b/Source/TableViewDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Victor Sigler. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 typealias DidSelectRowAtIndexPathClosure = (UITableView, IndexPath) -> Void
 typealias HeightForRowAtIndexPathClosure = (UITableView, IndexPath) -> CGFloat


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.