### PR TITLE
Added Deselect Delegate for children cell

### DIFF
--- a/Example/Views/AccordionTableViewController.swift
+++ b/Example/Views/AccordionTableViewController.swift
@@ -119,7 +119,11 @@ extension AccordionTableViewController {
         }
         
         let didSelectChildCell = { (tableView: UITableView, indexPath: IndexPath, item: CountryCellModel?) -> Void in
-            print("Child cell \(item!.name) tapped")
+            print("Child cell \(item!.name) selected")
+        }
+        
+        let didDeselectChildCell = { (tableView: UITableView, indexPath: IndexPath, item: Marker?) -> Void in
+            print("Child cell \(item!.icon) deselected")
         }
         
         let scrollViewDidScroll = { (scrollView: UIScrollView) -> Void in
@@ -133,6 +137,7 @@ extension AccordionTableViewController {
                 childCellConfig: childCellConfig,
                 didSelectParentAtIndexPath: didSelectParentCell,
                 didSelectChildAtIndexPath: didSelectChildCell,
+                didDeselectChildAtIndexPath: didDeselectChildCell,
                 scrollViewDidScroll: scrollViewDidScroll,
                 // Configure DataSourceProvider to have only one parent expanded at a time
                 numberOfExpandedParentCells: .single

--- a/Example/Views/AccordionViewController.swift
+++ b/Example/Views/AccordionViewController.swift
@@ -115,7 +115,11 @@ extension AccordionViewController {
         }
         
         let didSelectChildCell = { (tableView: UITableView, indexPath: IndexPath, item: CountryCellModel?) -> Void in
-            print("Child cell \(item!.name) tapped")
+            print("Child cell \(item!.name) selected")
+        }
+        
+        let didDeselectChildCell = { (tableView: UITableView, indexPath: IndexPath, item: Marker?) -> Void in
+            print("Child cell \(item!.name) deselected")
         }
         
         let heightForParentCell = { (tableView: UITableView, indexPath: IndexPath, item: ParentCellModel?) -> CGFloat in
@@ -137,6 +141,7 @@ extension AccordionViewController {
             childCellConfig: childCellConfig,
             didSelectParentAtIndexPath: didSelectParentCell,
             didSelectChildAtIndexPath: didSelectChildCell,
+            didDeselectChildAtIndexPath: didDeselectChildCell,
             heightForParentCellAtIndexPath: heightForParentCell,
             heightForChildCellAtIndexPath: heightForChildCell,
             scrollViewDidScroll: scrollViewDidScroll

--- a/Source/TableViewDelegate.swift
+++ b/Source/TableViewDelegate.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 typealias DidSelectRowAtIndexPathClosure = (UITableView, IndexPath) -> Void
+typealias DidDeselectRowAtIntexPathClosure = (UITableView, IndexPath) -> Void
 typealias HeightForRowAtIndexPathClosure = (UITableView, IndexPath) -> CGFloat
 public typealias ScrollViewDidScrollClosure = (UIScrollView) -> Void
 
@@ -17,6 +18,7 @@ public typealias ScrollViewDidScrollClosure = (UIScrollView) -> Void
     // MARK: - Properties
     
     var didSelectRowAtIndexPath: DidSelectRowAtIndexPathClosure?
+    var didDeselectRowAtIndexPath: DidDeselectRowAtIntexPathClosure?
     var heightForRowAtIndexPath: HeightForRowAtIndexPathClosure?
     
     var scrollViewDidScrollClosure: ScrollViewDidScrollClosure?
@@ -26,6 +28,10 @@ extension TableViewDelegate: UITableViewDelegate {
     
     @objc func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         didSelectRowAtIndexPath?(tableView, indexPath)
+    }
+    
+    @objc func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        didDeselectRowAtIndexPath?(tableView, indexPath)
     }
     
     @objc func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {


### PR DESCRIPTION
Added a deselect delegate so that user is informed when a children cell is deselected. 
Very useful when you need to track the state of the children cell since at the moment in a multi edit table you can't know which one was deselected.